### PR TITLE
Bugfix: Fixes whitelist removability for both creation and editing

### DIFF
--- a/chronicle-front/src/app/components/edit-whitelist/edit-whitelist.component.html
+++ b/chronicle-front/src/app/components/edit-whitelist/edit-whitelist.component.html
@@ -1,2 +1,5 @@
-<app-whitelist-select (whitelist)="setUserList($event)" [currentWhitelist]="media?.whitelist" ></app-whitelist-select>
+<app-whitelist-select
+  (whitelist)="setUserList($event)"
+  [currentWhitelist]="media?.whitelist"
+  [uploadingUserId]="uploadingUserId"></app-whitelist-select>
 <button class="upload-button" mat-flat-button color="primary" (click)="update()">Update</button>

--- a/chronicle-front/src/app/components/edit-whitelist/edit-whitelist.component.ts
+++ b/chronicle-front/src/app/components/edit-whitelist/edit-whitelist.component.ts
@@ -15,6 +15,7 @@ export class EditWhitelistComponent implements OnInit {
 
   @Input() media: any;
   userWhitelist: any;
+  uploadingUserId : string | undefined;
 
   constructor(private updateWhitellist: UpdateWhitelistService) { }
 

--- a/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.html
+++ b/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.html
@@ -6,10 +6,15 @@
           *ngFor = "let user of selectedUsers"
           [removable]="removable"
           (removed) = "toggleSelection(user)">
-          <span [attr.aria-label]="user.email + '; Press backspace to delete'">
+          <span
+            *ngIf="removable && user.email != currentUser.email; else nonRemovable"
+            [attr.aria-label]="user.email + '; press backspace to delete'">
             {{user.email}}
+            <mat-icon matChipRemove>cancel</mat-icon>
           </span>
-          <mat-icon matChipRemove *ngIf="removable && user.email != currentUser.email">cancel</mat-icon>
+          <ng-template #nonRemovable>
+            {{user.email}}
+          </ng-template>
         </mat-chip>
         <input
           placeholder="Enter User"

--- a/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
+++ b/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
@@ -116,6 +116,11 @@ export class WhitelistSelectComponent implements OnInit {
     * @param user, the selected user.
     */
   toggleSelection(user: any) {
+    // refuse to ever *un*check the current user
+    if (user.selected && user.email == this.currentUser.email) {
+      return;
+    }
+
     user.selected! = !user.selected;
     if (user.selected) {
       console.log(user.selected);

--- a/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
+++ b/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
@@ -116,7 +116,7 @@ export class WhitelistSelectComponent implements OnInit {
     */
   toggleSelection(user: any) {
     // refuse to ever *un*check the uploading user
-    if (user.selected && user.email == this.uploadingUserId) {
+    if (user.selected && user.email === this.uploadingUserId) {
       return;
     }
 

--- a/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
+++ b/chronicle-front/src/app/components/whitelist-select/whitelist-select.component.ts
@@ -27,7 +27,7 @@ export class WhitelistSelectComponent implements OnInit {
   selectedUsers: DisplayUser[] = [];
   filteredUsers!:Observable<DisplayUser[]>;
   lastFilter: string = '';
-  currentUser: any;
+  uploadingUserId : string | null | undefined;
 
   constructor(private userService: UsersService, private auth: AuthService) { }
 
@@ -42,23 +42,22 @@ export class WhitelistSelectComponent implements OnInit {
       if(!resp)
         return;
 
-      this.currentUser = resp;
-
       if(!this.currentWhitelist){
-        let newCurrent = {uid: null, displayName: null, email: "", selected: false };
-        newCurrent.email = this.currentUser.email;
-        newCurrent.displayName = this.currentUser.displayName;
-        newCurrent.uid = this.currentUser.uid;
-        console.log(newCurrent);
-        this.toggleSelection(newCurrent);
+        this.uploadingUserId = resp.email;
+        this.toggleSelection(resp);
       }
 
     })
 
     this.userService.Users.pipe(take(2)).subscribe((resp: any[]) =>{
+      // sommething is likely seriously wrong if true though
+      if (this.uploadingUserId === undefined) {
+        return;
+      }
+
       this.users = resp;
-      if(!this.currentWhitelist){
-        const i = this.users.findIndex(value => value.email! === this.currentUser.email)
+      if(!this.currentWhitelist && this.uploadingUserId !== undefined){
+        const i = this.users.findIndex(value => value.email! === this.uploadingUserId)
         this.users.splice(i, 1);
       }
       this.filteredUsers = this.userControl.valueChanges.pipe(
@@ -116,8 +115,8 @@ export class WhitelistSelectComponent implements OnInit {
     * @param user, the selected user.
     */
   toggleSelection(user: any) {
-    // refuse to ever *un*check the current user
-    if (user.selected && user.email == this.currentUser.email) {
+    // refuse to ever *un*check the uploading user
+    if (user.selected && user.email == this.uploadingUserId) {
       return;
     }
 


### PR DESCRIPTION
if creating a new whitelist

```HTML
<whitelist-select [properties and stuff ...]></whitelist-select>
```

if editing an existing whitelist

```HTML
<whitelist-select
  [uploadingUserId]="[insert email address here]"
  [other properties and stuff ...]></whitelist-select>
```

`EditWhitelistComponent` now accepts an `uploadingUserId` propertry which it forwards to the underlying `WhitelistSelectComponent`